### PR TITLE
Link trips to vehicles

### DIFF
--- a/Backend/src/controllers/TripController.ts
+++ b/Backend/src/controllers/TripController.ts
@@ -5,38 +5,52 @@ import { AuthRequest } from "../middleware/auth";
 const service = new TripService();
 
 export class TripController {
-	static async create(req: AuthRequest, res: Response): Promise<void> {
-		try {
-			const { kilometers, gallons } = req.body;
-			const trip = await service.create(req.userId!, kilometers, gallons);
-			res.status(201).json(trip);
-		} catch (err: any) {
-			res.status(400).json({ message: err.message });
-		}
-	}
+        static async create(req: AuthRequest, res: Response): Promise<void> {
+                try {
+                        const { kilometers, gallons, vehicleId } = req.body;
+                        if (!vehicleId) {
+                                res.status(400).json({ message: "vehicleId requerido" });
+                                return;
+                        }
+                        const trip = await service.create(req.userId!, vehicleId, kilometers, gallons);
+                        res.status(201).json(trip);
+                } catch (err: any) {
+                        res.status(400).json({ message: err.message });
+                }
+        }
 
-	static async list(req: AuthRequest, res: Response): Promise<void> {
-		try {
-			const data = await service.listWithSummary(req.userId!);
-			res.json(data);
-		} catch (err: any) {
-			res.status(400).json({ message: err.message });
-		}
-	}
+        static async list(req: AuthRequest, res: Response): Promise<void> {
+                try {
+                        const { vehicleId } = req.query as { vehicleId: string };
+                        if (!vehicleId) {
+                                res.status(400).json({ message: "vehicleId requerido" });
+                                return;
+                        }
+                        const data = await service.listWithSummary(req.userId!, vehicleId);
+                        res.json(data);
+                } catch (err: any) {
+                        res.status(400).json({ message: err.message });
+                }
+        }
 
-	static async calculate(req: AuthRequest, res: Response): Promise<void> {
-		try {
-			const km = parseFloat(req.query.km as string);
-			if (isNaN(km) || km <= 0) {
-				res.status(400).json({ message: "Parámetro km inválido" });
-				return;
-			}
-			const result = await service.calculate(req.userId!, km);
-			console.log(result);
-			res.json(result);
-		} catch (err: any) {
-			res.status(400).json({ message: err.message });
-		}
+        static async calculate(req: AuthRequest, res: Response): Promise<void> {
+                try {
+                        const { vehicleId } = req.query as { vehicleId: string };
+                        if (!vehicleId) {
+                                res.status(400).json({ message: "vehicleId requerido" });
+                                return;
+                        }
+                        const km = parseFloat(req.query.km as string);
+                        if (isNaN(km) || km <= 0) {
+                                res.status(400).json({ message: "Parámetro km inválido" });
+                                return;
+                        }
+                        const result = await service.calculate(req.userId!, vehicleId, km);
+                        console.log(result);
+                        res.json(result);
+                } catch (err: any) {
+                        res.status(400).json({ message: err.message });
+                }
 	}
 
 	static async delete(req: AuthRequest, res: Response): Promise<void> {

--- a/Backend/src/models/Trip.ts
+++ b/Backend/src/models/Trip.ts
@@ -1,17 +1,19 @@
 import { Schema, model, Document } from "mongoose";
 
 export interface ITrip extends Document {
-	userId: Schema.Types.ObjectId;
-	kilometers: number;
-	gallons: number;
-	createdAt: Date;
+        userId: Schema.Types.ObjectId;
+        vehicleId: Schema.Types.ObjectId;
+        kilometers: number;
+        gallons: number;
+        createdAt: Date;
 }
 
 const tripSchema = new Schema<ITrip>({
-	userId: { type: Schema.Types.ObjectId, ref: "User", required: true },
-	kilometers: { type: Number, required: true },
-	gallons: { type: Number, required: true },
-	createdAt: { type: Date, default: Date.now },
+        userId: { type: Schema.Types.ObjectId, ref: "User", required: true },
+        vehicleId: { type: Schema.Types.ObjectId, ref: "Vehicle", required: true },
+        kilometers: { type: Number, required: true },
+        gallons: { type: Number, required: true },
+        createdAt: { type: Date, default: Date.now },
 });
 
 export const Trip = model<ITrip>("Trip", tripSchema);

--- a/Backend/src/models/Vehicle.ts
+++ b/Backend/src/models/Vehicle.ts
@@ -4,6 +4,7 @@ export interface IVehicle extends Document {
     userId: Schema.Types.ObjectId;
     name: string;
     licensePlate: string;
+    isDefault: boolean;
     createdAt: Date;
     updatedAt: Date;
 }
@@ -13,6 +14,7 @@ const vehicleSchema = new Schema<IVehicle>(
         userId: { type: Schema.Types.ObjectId, ref: "User", required: true },
         name: { type: String, required: true },
         licensePlate: { type: String, required: true },
+        isDefault: { type: Boolean, default: false },
     },
     { timestamps: true }
 );

--- a/Backend/src/repositories/TripRepository.ts
+++ b/Backend/src/repositories/TripRepository.ts
@@ -2,23 +2,36 @@ import { Trip, ITrip } from "../models/Trip";
 import { Types } from "mongoose";
 
 export class TripRepository {
-	async create(data: {
-		userId: string;
-		kilometers: number;
-		gallons: number;
-	}): Promise<ITrip> {
-		return Trip.create({
-			userId: new Types.ObjectId(data.userId),
-			kilometers: data.kilometers,
-			gallons: data.gallons,
-		});
-	}
+        async create(data: {
+                userId: string;
+                vehicleId: string;
+                kilometers: number;
+                gallons: number;
+        }): Promise<ITrip> {
+                return Trip.create({
+                        userId: new Types.ObjectId(data.userId),
+                        vehicleId: new Types.ObjectId(data.vehicleId),
+                        kilometers: data.kilometers,
+                        gallons: data.gallons,
+                });
+        }
 
-	async findByUser(userId: string): Promise<ITrip[]> {
-		return Trip.find({ userId: new Types.ObjectId(userId) }).sort({
-			createdAt: -1,
-		});
-	}
+        async findByVehicle(userId: string, vehicleId: string): Promise<ITrip[]> {
+                return Trip.find({
+                        userId: new Types.ObjectId(userId),
+                        vehicleId: new Types.ObjectId(vehicleId),
+                }).sort({ createdAt: -1 });
+        }
+
+        async assignVehicleToOldTrips(userId: string, vehicleId: string): Promise<void> {
+                await Trip.updateMany(
+                        {
+                                userId: new Types.ObjectId(userId),
+                                $or: [{ vehicleId: { $exists: false } }, { vehicleId: null }],
+                        },
+                        { vehicleId: new Types.ObjectId(vehicleId) }
+                );
+        }
 
 	
 

--- a/Backend/src/repositories/VehicleRepository.ts
+++ b/Backend/src/repositories/VehicleRepository.ts
@@ -10,8 +10,21 @@ export class VehicleRepository {
         });
     }
 
+    async createDefault(userId: string): Promise<IVehicle> {
+        return Vehicle.create({
+            userId: new Types.ObjectId(userId),
+            name: "Vehiculo por defecto",
+            licensePlate: "DEFAULT",
+            isDefault: true,
+        });
+    }
+
     async findByUser(userId: string): Promise<IVehicle[]> {
         return Vehicle.find({ userId: new Types.ObjectId(userId) }).sort({ createdAt: -1 });
+    }
+
+    async findDefault(userId: string): Promise<IVehicle | null> {
+        return Vehicle.findOne({ userId: new Types.ObjectId(userId), isDefault: true });
     }
 
     async findById(userId: string, id: string): Promise<IVehicle | null> {

--- a/Backend/src/services/TripService.ts
+++ b/Backend/src/services/TripService.ts
@@ -1,5 +1,6 @@
 import { TripRepository } from "../repositories/TripRepository";
 import { UserRepository } from "../repositories/UserRepository";
+import { VehicleService } from "./VehicleService";
 import { ITrip } from "../models/Trip";
 import {
 	average,
@@ -10,15 +11,19 @@ import {
 } from "../utils/calculate";
 
 export class TripService {
-	private tripRepo = new TripRepository();
-	private userRepo = new UserRepository();
+        private tripRepo = new TripRepository();
+        private userRepo = new UserRepository();
+        private vehicleSvc = new VehicleService();
 
-	async create(userId: string, km: number, gal: number): Promise<ITrip> {
-		return this.tripRepo.create({ userId, kilometers: km, gallons: gal });
-	}
+        async create(userId: string, vehicleId: string, km: number, gal: number): Promise<ITrip> {
+                await this.vehicleSvc.ensureDefaultVehicle(userId);
+                return this.tripRepo.create({ userId, vehicleId, kilometers: km, gallons: gal });
+        }
 
-	async listWithSummary(userId: string) {
-		const trips = await this.tripRepo.findByUser(userId);
+        async listWithSummary(userId: string, vehicleId: string) {
+                await this.vehicleSvc.ensureDefaultVehicle(userId);
+                await this.tripRepo.assignVehicleToOldTrips(userId, vehicleId);
+                const trips = await this.tripRepo.findByVehicle(userId, vehicleId);
 
 		const kmsArr = trips.map((t) => t.kilometers);
 		const galArr = trips.map((t) => t.gallons);
@@ -42,8 +47,8 @@ export class TripService {
 		};
 	}
 
-	async calculate(userId: string, km: number) {
-		const { summary } = await this.listWithSummary(userId);
+        async calculate(userId: string, vehicleId: string, km: number) {
+                const { summary } = await this.listWithSummary(userId, vehicleId);
 		const user = await this.userRepo.findById(userId);
 		if (!user) throw new Error("Usuario no encontrado");
 

--- a/Backend/src/services/VehicleService.ts
+++ b/Backend/src/services/VehicleService.ts
@@ -4,6 +4,18 @@ import { IVehicle } from "../models/Vehicle";
 export class VehicleService {
     private repo = new VehicleRepository();
 
+    async ensureDefaultVehicle(userId: string): Promise<IVehicle> {
+        let vehicle = await this.repo.findDefault(userId);
+        if (!vehicle) {
+            vehicle = await this.repo.createDefault(userId);
+        }
+        return vehicle;
+    }
+
+    async getDefaultVehicle(userId: string): Promise<IVehicle> {
+        return this.ensureDefaultVehicle(userId);
+    }
+
     async create(userId: string, name: string, licensePlate: string): Promise<IVehicle> {
         return this.repo.create({ userId, name, licensePlate });
     }

--- a/Frontend/src/app/(protected)/calculator/page.tsx
+++ b/Frontend/src/app/(protected)/calculator/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from "react";
 import { useCalculate } from "@/hooks/useCalculate";
+import { useVehicles } from "@/hooks/useVehicles";
 import Link from "next/link";
 import { motion } from "framer-motion";
 import { Input } from "@/components/ui/input";
@@ -17,6 +18,8 @@ const formatCOP = (value: number) => {
 };
 
 export default function CalculatorPage() {
+  const { vehicles, loading: vehLoading } = useVehicles();
+  const [vehicleId, setVehicleId] = useState<string>("");
   const { user } = useAuth();
   const corrientePrice = user?.fuelPrices.corriente ?? 0;
   const extraPrice = user?.fuelPrices.extra ?? 0;
@@ -45,8 +48,21 @@ export default function CalculatorPage() {
     );
   }
 
+  if (vehLoading)
+    return <p className="p-4 text-center text-gray-500">Cargando datos...</p>;
+  if (!vehicleId)
+    return (
+      <p className="p-4 text-center text-gray-500">Debes crear un vehículo antes de continuar.</p>
+    );
+
   const [km, setKm] = useState<string>("");
-  const { data, loading, error, calculate } = useCalculate();
+  const { data, loading, error, calculate } = useCalculate(vehicleId);
+
+  React.useEffect(() => {
+    if (!vehicleId && vehicles.length > 0) {
+      setVehicleId(vehicles[0]._id);
+    }
+  }, [vehicles, vehicleId]);
 
   const handleKmChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
@@ -95,6 +111,20 @@ export default function CalculatorPage() {
           </CardHeader>
           <CardContent className="space-y-6 bg-white p-6">
             <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <Label className="text-gray-600">Vehículo</Label>
+                <select
+                  value={vehicleId}
+                  onChange={(e) => setVehicleId(e.target.value)}
+                  className="mt-1 w-full border rounded p-2"
+                >
+                  {vehicles.map((v) => (
+                    <option key={v._id} value={v._id}>
+                      {v.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
               <div>
                 <Label htmlFor="km" className="text-gray-600">
                   Kilómetros

--- a/Frontend/src/app/(protected)/dashboard/page.tsx
+++ b/Frontend/src/app/(protected)/dashboard/page.tsx
@@ -1,17 +1,32 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 import { useTrips } from "@/hooks/useTrips";
+import { useVehicles } from "@/hooks/useVehicles";
 import Link from "next/link";
 import { Trash2 } from "lucide-react";
 import { motion } from "framer-motion";
 
 export default function DashboardPage() {
-	const { data, loading, error, deleteTrip } = useTrips();
+        const { vehicles, loading: vehLoading } = useVehicles();
+        const [vehicleId, setVehicleId] = useState<string>("");
+        const { data, loading, error, deleteTrip } = useTrips(vehicleId);
 
-	if (loading)
-		return <p className="p-4 text-center text-gray-500">Cargando datos...</p>;
-	if (error) return <p className="p-4 text-center text-red-500">{error}</p>;
+        React.useEffect(() => {
+                if (!vehicleId && vehicles.length > 0) {
+                        setVehicleId(vehicles[0]._id);
+                }
+        }, [vehicles, vehicleId]);
+
+        if (vehLoading || loading)
+                return <p className="p-4 text-center text-gray-500">Cargando datos...</p>;
+        if (error) return <p className="p-4 text-center text-red-500">{error}</p>;
+        if (!vehicleId)
+                return (
+                        <p className="p-4 text-center text-gray-500">
+                                Debes crear un vehículo antes de continuar.
+                        </p>
+                );
 
 	return (
 		<div className="min-h-screen bg-gradient-to-br from-indigo-50 via-white to-sky-50">
@@ -28,12 +43,25 @@ export default function DashboardPage() {
 					Registra tus viajes, analiza tu consumo y optimiza tu rendimiento en
 					carretera.
 				</p>
-				<Link
-					href="/trips/new"
-					className="inline-block bg-indigo-600 text-white px-8 py-4 rounded-full shadow-lg hover:bg-indigo-700 transition">
-					+ Nuevo Viaje
-				</Link>
-			</motion.section>
+                                <div className="flex flex-col items-center gap-4">
+                                        <select
+                                                value={vehicleId}
+                                                onChange={(e) => setVehicleId(e.target.value)}
+                                                className="border rounded p-2">
+                                                {vehicles.map((v) => (
+                                                        <option key={v._id} value={v._id}>
+                                                                {v.name}
+                                                        </option>
+                                                ))}
+                                        </select>
+
+                                        <Link
+                                                href="/trips/new"
+                                                className="inline-block bg-indigo-600 text-white px-8 py-4 rounded-full shadow-lg hover:bg-indigo-700 transition">
+                                                + Nuevo Viaje
+                                        </Link>
+                                </div>
+                        </motion.section>
 
 			{/* Stats */}
 			<motion.section

--- a/Frontend/src/hooks/useCalculate.ts
+++ b/Frontend/src/hooks/useCalculate.ts
@@ -4,16 +4,16 @@ import { useState } from "react";
 import api from "@/lib/api";
 import { CalculateResponse } from "@/types";
 
-export function useCalculate() {
+export function useCalculate(vehicleId: string) {
 	const [data, setData] = useState<CalculateResponse | null>(null);
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 
-	const calculate = async (km: number) => {
-		setLoading(true);
-		setError(null);
-		try {
-			const res = await api.get<CalculateResponse>(`/trips/calculate?km=${km}`);
+        const calculate = async (km: number) => {
+                setLoading(true);
+                setError(null);
+                try {
+                        const res = await api.get<CalculateResponse>(`/trips/calculate?km=${km}&vehicleId=${vehicleId}`);
 			setData(res.data);
 		} catch (err: any) {
 			setError(

--- a/Frontend/src/hooks/useTrips.ts
+++ b/Frontend/src/hooks/useTrips.ts
@@ -9,28 +9,28 @@ interface TripsData {
 	summary: TripSummaryResponse;
 }
 
-export function useTrips() {
+export function useTrips(vehicleId: string) {
 	const [data, setData] = useState<TripsData | null>(null);
 	const [loading, setLoading] = useState<boolean>(true);
 	const [error, setError] = useState<string | null>(null);
 
-	const fetchData = useCallback(() => {
-		setLoading(true);
-		api
-			.get<TripsData>("/trips")
+        const fetchData = useCallback(() => {
+                setLoading(true);
+                api
+                        .get<TripsData>(`/trips?vehicleId=${vehicleId}`)
 			.then((res) => setData(res.data))
 			.catch((err) => setError(err.message || "Error al cargar viajes"))
 			.finally(() => setLoading(false));
-	}, []);
+        }, [vehicleId]);
 
 	useEffect(() => {
 		fetchData();
-	}, [fetchData]);
+        }, [fetchData]);
 
 	const deleteTrip = async (id: string) => {
-		await api.delete(`/trips/${id}`);
-		fetchData();
-	};
+                await api.delete(`/trips/${id}`);
+                fetchData();
+        };
 
 	return { data, loading, error, deleteTrip };
 }

--- a/Frontend/src/types/index.ts
+++ b/Frontend/src/types/index.ts
@@ -13,11 +13,12 @@ export interface AuthResponse {
 }
 
 export interface ITrip {
-	_id: string;
-	userId: string;
-	kilometers: number;
-	gallons: number;
-	createdAt: string;
+        _id: string;
+        userId: string;
+        vehicleId: string;
+        kilometers: number;
+        gallons: number;
+        createdAt: string;
 }
 
 export interface TripSummary {


### PR DESCRIPTION
## Summary
- assign trips to specific vehicles in models and services
- create default vehicle for users and migrate old trips
- require vehicle ID when listing, calculating or creating trips
- update hooks and pages to select a vehicle

## Testing
- `npm run build` in Backend
- `npm test` in Backend *(fails: Error: no test specified)*
- `npm run build` in Frontend
- `npm test` in Frontend *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6887b61026ac8326b77c454d185bb234