### PR TITLE
Implement basic user role support

### DIFF
--- a/Backend/src/controllers/AuthController.ts
+++ b/Backend/src/controllers/AuthController.ts
@@ -8,11 +8,16 @@ export class AuthController {
 	static async signup(req: Request, res: Response) {
 		try {
 			const { email, password } = req.body;
-			const { user, token } = await service.register(email, password);
-			res.status(201).json({
-				user: { id: user.id, email: user.email, fuelPrices: user.fuelPrices },
-				token,
-			});
+                const { user, token } = await service.register(email, password);
+                res.status(201).json({
+                                user: {
+                                        id: user.id,
+                                        email: user.email,
+                                        fuelPrices: user.fuelPrices,
+                                        role: user.role,
+                                },
+                                token,
+                        });
 		} catch (err: any) {
 			res.status(400).json({ message: err.message });
 		}
@@ -21,11 +26,16 @@ export class AuthController {
 	static async login(req: Request, res: Response) {
 		try {
 			const { email, password } = req.body;
-			const { user, token } = await service.login(email, password);
-			res.json({
-				user: { id: user.id, email: user.email, fuelPrices: user.fuelPrices },
-				token,
-			});
+                const { user, token } = await service.login(email, password);
+                res.json({
+                                user: {
+                                        id: user.id,
+                                        email: user.email,
+                                        fuelPrices: user.fuelPrices,
+                                        role: user.role,
+                                },
+                                token,
+                        });
 		} catch (err: any) {
 			res.status(400).json({ message: err.message });
 		}
@@ -56,11 +66,11 @@ export class AuthController {
 		}
 	}
 
-	static async googleCallback(req: Request, res: Response) {
-		const user = req.user as any;
-		const token = new UserService().generateToken(user.id);
-		return res.redirect(
-			`${process.env.FRONTEND_URL}/auth/social?token=${token}`
-		);
-	}
+        static async googleCallback(req: Request, res: Response) {
+                const user = req.user as any;
+                const token = new UserService().generateToken(user.id, user.role);
+                return res.redirect(
+                        `${process.env.FRONTEND_URL}/auth/social?token=${token}`
+                );
+        }
 }

--- a/Backend/src/middleware/auth.ts
+++ b/Backend/src/middleware/auth.ts
@@ -3,7 +3,8 @@ import jwt from "jsonwebtoken";
 import { config } from "../config";
 
 export interface AuthRequest extends Request {
-	userId?: string;
+        userId?: string;
+        role?: string;
 }
 
 export const authenticate = (
@@ -17,10 +18,14 @@ export const authenticate = (
 		return;
 	}
 	const token = authHeader.split(" ")[1];
-	try {
-		const payload = jwt.verify(token, config.JWT_SECRET) as { userId: string };
-		req.userId = payload.userId;
-		next();
+        try {
+                const payload = jwt.verify(token, config.JWT_SECRET) as {
+                        userId: string;
+                        role?: string;
+                };
+                req.userId = payload.userId;
+                req.role = payload.role;
+                next();
 	} catch {
 		res.status(401).json({ message: "Invalid or expired token" });
 	}

--- a/Backend/src/middleware/authorize.ts
+++ b/Backend/src/middleware/authorize.ts
@@ -1,0 +1,11 @@
+import { Response, NextFunction } from "express";
+import { AuthRequest } from "./auth";
+
+export function authorize(roles: string[]) {
+    return (req: AuthRequest, res: Response, next: NextFunction) => {
+        if (!req.role || !roles.includes(req.role)) {
+            return res.status(403).json({ message: "Forbidden" });
+        }
+        next();
+    };
+}

--- a/Backend/src/models/User.ts
+++ b/Backend/src/models/User.ts
@@ -1,28 +1,36 @@
 import { Schema, model, Document } from "mongoose";
 
+export type UserRole = "user" | "admin";
+
 export interface IUser extends Document {
-	email: string;
-	password: string;
-	googleId: string;
-	fuelPrices: {
-		corriente: number;
-		extra: number;
-	};
-	createdAt: Date;
+        email: string;
+        password: string;
+        googleId: string;
+        role: UserRole;
+        fuelPrices: {
+                corriente: number;
+                extra: number;
+        };
+        createdAt: Date;
 	updatedAt: Date;
 }
 
 const userSchema = new Schema<IUser>(
-	{
-		email: { type: String, required: true, unique: true },
-		password: { type: String },
-		googleId: { type: String, unique: true, sparse: true },
-		fuelPrices: {
-			corriente: { type: Number, default: 0 },
-			extra: { type: Number, default: 0 },
-		},
-	},
-	{ timestamps: true }
+        {
+                email: { type: String, required: true, unique: true },
+                password: { type: String },
+                googleId: { type: String, unique: true, sparse: true },
+                role: {
+                        type: String,
+                        enum: ["user", "admin"],
+                        default: "user",
+                },
+                fuelPrices: {
+                        corriente: { type: Number, default: 0 },
+                        extra: { type: Number, default: 0 },
+                },
+        },
+        { timestamps: true }
 );
 
 export const User = model<IUser>("User", userSchema);

--- a/Backend/src/services/UserService.ts
+++ b/Backend/src/services/UserService.ts
@@ -2,6 +2,7 @@ import bcrypt from "bcrypt";
 import jwt from "jsonwebtoken";
 import { config } from "../config";
 import { UserRepository } from "../repositories/UserRepository";
+import { UserRole } from "../models/User";
 import { VehicleService } from "./VehicleService";
 
 const SALT_ROUNDS = 10;
@@ -10,16 +11,20 @@ export class UserService {
         private repo = new UserRepository();
         private vehicleSvc = new VehicleService();
 
-	async register(email: string, plainPassword: string) {
-		const existing = await this.repo.findByEmail(email);
-		if (existing) throw new Error("Email already in use");
+        async register(email: string, plainPassword: string) {
+                const existing = await this.repo.findByEmail(email);
+                if (existing) throw new Error("Email already in use");
 
-		const hash = await bcrypt.hash(plainPassword, SALT_ROUNDS);
-                const user = await this.repo.create({ email, password: hash });
+                const hash = await bcrypt.hash(plainPassword, SALT_ROUNDS);
+                const user = await this.repo.create({
+                        email,
+                        password: hash,
+                        role: "user",
+                });
                 await this.vehicleSvc.ensureDefaultVehicle(user.id);
-                const token = this.signToken(user.id);
+                const token = this.signToken(user.id, user.role);
                 return { user, token };
-	}
+        }
 
         async login(email: string, plainPassword: string) {
                 const user = await this.repo.findByEmail(email);
@@ -29,9 +34,9 @@ export class UserService {
 		if (!valid) throw new Error("Invalid credentials");
 
                 await this.vehicleSvc.ensureDefaultVehicle(user.id);
-                const token = this.signToken(user.id);
+                const token = this.signToken(user.id, user.role);
                 return { user, token };
-	}
+        }
 
 	async me(userId: string) {
 		const user = await this.repo.findById(userId);
@@ -40,10 +45,11 @@ export class UserService {
 			id: user.id,
 			email: user.email,
 			fuelPrices: user.fuelPrices,
-			createdAt: user.createdAt,
-			updatedAt: user.updatedAt,
-		};
-	}
+                        createdAt: user.createdAt,
+                        updatedAt: user.updatedAt,
+                        role: user.role,
+                };
+        }
 
 	async findOrCreateByGoogle(googleId: string, email: string) {
                 let user = await this.repo.findByGoogleId(googleId);
@@ -59,7 +65,12 @@ export class UserService {
                         return linked;
                 }
 
-                const created = await this.repo.create({ email, googleId, password: "" });
+                const created = await this.repo.create({
+                        email,
+                        googleId,
+                        password: "",
+                        role: "user",
+                });
                 await this.vehicleSvc.ensureDefaultVehicle(created.id);
                 return created;
         }
@@ -76,15 +87,18 @@ export class UserService {
 		return {
 			id: updated.id,
 			email: updated.email,
-			fuelPrices: updated.fuelPrices,
-		};
-	}
+                        fuelPrices: updated.fuelPrices,
+                        role: updated.role,
+                };
+        }
 
-	private signToken(userId: string) {
-		return jwt.sign({ userId }, config.JWT_SECRET, { expiresIn: "7d" });
-	}
+        private signToken(userId: string, role: UserRole) {
+                return jwt.sign({ userId, role }, config.JWT_SECRET, {
+                        expiresIn: "7d",
+                });
+        }
 
-	public generateToken(userId: string) {
-		return this.signToken(userId);
-	}
+        public generateToken(userId: string, role: UserRole) {
+                return this.signToken(userId, role);
+        }
 }

--- a/Frontend/src/components/RoleGuard.tsx
+++ b/Frontend/src/components/RoleGuard.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { ReactNode, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/contexts/AuthContext";
+
+interface RoleGuardProps {
+    requiredRole: "admin" | "user";
+    children: ReactNode;
+    fallback?: ReactNode;
+}
+
+export default function RoleGuard({ requiredRole, children, fallback }: RoleGuardProps) {
+    const { user, loading } = useAuth();
+    const router = useRouter();
+
+    useEffect(() => {
+        if (!loading && user && user.role !== requiredRole) {
+            router.replace("/unauthorized");
+        }
+    }, [loading, user, router, requiredRole]);
+
+    if (loading) {
+        return null;
+    }
+
+    if (!user || user.role !== requiredRole) {
+        return <>{fallback ?? null}</>;
+    }
+
+    return <>{children}</>;
+}

--- a/Frontend/src/types/index.ts
+++ b/Frontend/src/types/index.ts
@@ -1,10 +1,11 @@
 export interface User {
-	id: string;
-	email: string;
-	fuelPrices: {
-		corriente: number;
-		extra: number;
-	};
+        id: string;
+        email: string;
+        role: "user" | "admin";
+        fuelPrices: {
+                corriente: number;
+                extra: number;
+        };
 }
 
 export interface AuthResponse {


### PR DESCRIPTION
## Summary
- add `role` field to user schema and service
- include user roles in auth responses
- expose `authorize` middleware for role checks
- update frontend types and add `RoleGuard` component

## Testing
- `npm run build` in `Backend`
- `npm run build` in `Frontend`


------
https://chatgpt.com/codex/tasks/task_e_68892cdc85d48326b93fd325dbee1fe4