### PR TITLE
feat: add default vehicle only for legacy users

### DIFF
--- a/Backend/src/repositories/TripRepository.ts
+++ b/Backend/src/repositories/TripRepository.ts
@@ -23,6 +23,11 @@ export class TripRepository {
                 }).sort({ createdAt: -1 });
         }
 
+        async userHasTrips(userId: string): Promise<boolean> {
+                const count = await Trip.countDocuments({ userId: new Types.ObjectId(userId) });
+                return count > 0;
+        }
+
         async assignVehicleToOldTrips(userId: string, vehicleId: string): Promise<void> {
                 await Trip.updateMany(
                         {

--- a/Backend/src/services/TripService.ts
+++ b/Backend/src/services/TripService.ts
@@ -17,12 +17,15 @@ export class TripService {
 
         async create(userId: string, vehicleId: string, km: number, gal: number): Promise<ITrip> {
                 await this.vehicleSvc.ensureDefaultVehicle(userId);
+                const vehicle = await this.vehicleSvc.findById(userId, vehicleId);
+                if (!vehicle) {
+                        throw new Error("Debes crear un vehículo antes de registrar el consumo");
+                }
                 return this.tripRepo.create({ userId, vehicleId, kilometers: km, gallons: gal });
         }
 
         async listWithSummary(userId: string, vehicleId: string) {
-                const defaultVeh = await this.vehicleSvc.ensureDefaultVehicle(userId);
-                await this.tripRepo.assignVehicleToOldTrips(userId, defaultVeh.id);
+                await this.vehicleSvc.ensureDefaultVehicle(userId);
                 const trips = await this.tripRepo.findByVehicle(userId, vehicleId);
 
 		const kmsArr = trips.map((t) => t.kilometers);

--- a/Backend/src/services/VehicleService.ts
+++ b/Backend/src/services/VehicleService.ts
@@ -1,18 +1,25 @@
 import { VehicleRepository } from "../repositories/VehicleRepository";
+import { TripRepository } from "../repositories/TripRepository";
 import { IVehicle } from "../models/Vehicle";
 
 export class VehicleService {
     private repo = new VehicleRepository();
+    private tripRepo = new TripRepository();
 
-    async ensureDefaultVehicle(userId: string): Promise<IVehicle> {
+    async ensureDefaultVehicle(userId: string): Promise<IVehicle | null> {
         let vehicle = await this.repo.findDefault(userId);
         if (!vehicle) {
+            const hasTrips = await this.tripRepo.userHasTrips(userId);
+            if (!hasTrips) {
+                return null;
+            }
             vehicle = await this.repo.createDefault(userId);
+            await this.tripRepo.assignVehicleToOldTrips(userId, vehicle.id);
         }
         return vehicle;
     }
 
-    async getDefaultVehicle(userId: string): Promise<IVehicle> {
+    async getDefaultVehicle(userId: string): Promise<IVehicle | null> {
         return this.ensureDefaultVehicle(userId);
     }
 
@@ -22,6 +29,10 @@ export class VehicleService {
 
     async list(userId: string): Promise<IVehicle[]> {
         return this.repo.findByUser(userId);
+    }
+
+    async findById(userId: string, id: string): Promise<IVehicle | null> {
+        return this.repo.findById(userId, id);
     }
 
     async update(


### PR DESCRIPTION
## Summary
- only create default vehicle for users that already have trip records
- require users to create a vehicle before recording new trips

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f8950742483269c5e632b935fe89d