### PR TITLE
fix: avoid creating unnecessary default vehicle

### DIFF
--- a/Backend/src/repositories/TripRepository.ts
+++ b/Backend/src/repositories/TripRepository.ts
@@ -28,6 +28,14 @@ export class TripRepository {
                 return count > 0;
         }
 
+        async userHasTripsWithoutVehicle(userId: string): Promise<boolean> {
+                const count = await Trip.countDocuments({
+                        userId: new Types.ObjectId(userId),
+                        $or: [{ vehicleId: { $exists: false } }, { vehicleId: null }],
+                });
+                return count > 0;
+        }
+
         async assignVehicleToOldTrips(userId: string, vehicleId: string): Promise<void> {
                 await Trip.updateMany(
                         {

--- a/Backend/src/services/VehicleService.ts
+++ b/Backend/src/services/VehicleService.ts
@@ -8,14 +8,17 @@ export class VehicleService {
 
     async ensureDefaultVehicle(userId: string): Promise<IVehicle | null> {
         let vehicle = await this.repo.findDefault(userId);
-        if (!vehicle) {
-            const hasTrips = await this.tripRepo.userHasTrips(userId);
-            if (!hasTrips) {
-                return null;
-            }
-            vehicle = await this.repo.createDefault(userId);
-            await this.tripRepo.assignVehicleToOldTrips(userId, vehicle.id);
+        if (vehicle) {
+            return vehicle;
         }
+
+        const needsDefault = await this.tripRepo.userHasTripsWithoutVehicle(userId);
+        if (!needsDefault) {
+            return null;
+        }
+
+        vehicle = await this.repo.createDefault(userId);
+        await this.tripRepo.assignVehicleToOldTrips(userId, vehicle.id);
         return vehicle;
     }
 


### PR DESCRIPTION
## Summary
- only create default vehicle when user has trips without a vehicle
- detect trips without vehicle in repository

## Testing
- `npm ci`
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f8ca025048326bf4c948e9d6e6bc5