### PR TITLE
feat: show fuel cost per kilometer

### DIFF
--- a/Frontend/src/app/(protected)/calculator/page.tsx
+++ b/Frontend/src/app/(protected)/calculator/page.tsx
@@ -10,12 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { useAuth } from "@/contexts/AuthContext";
-
-// Helper para formatear a COP con separador de miles y sin decimales
-const formatCOP = (value: number) => {
-  const rounded = Math.round(value);
-  return `$${rounded.toLocaleString("es-CO")}`;
-};
+import { formatCOP } from "@/lib/format";
 
 export default function CalculatorPage() {
   const { vehicles, loading: vehLoading } = useVehicles();
@@ -181,6 +176,16 @@ export default function CalculatorPage() {
                 <div className="bg-indigo-50 rounded-xl shadow p-4 text-center">
                   <p className="text-gray-500">Precio Extra</p>
                   <p className="text-2xl font-bold text-green-600">{formatCOP(data.cost.extra)}</p>
+                </div>
+                {/* Precio/Km Corriente */}
+                <div className="bg-indigo-50 rounded-xl shadow p-4 text-center">
+                  <p className="text-gray-500">Precio/Km Corriente</p>
+                  <p className="text-2xl font-bold text-green-600">{formatCOP(data.cost.corriente / data.kilometers)}</p>
+                </div>
+                {/* Precio/Km Extra */}
+                <div className="bg-indigo-50 rounded-xl shadow p-4 text-center">
+                  <p className="text-gray-500">Precio/Km Extra</p>
+                  <p className="text-2xl font-bold text-green-600">{formatCOP(data.cost.extra / data.kilometers)}</p>
                 </div>
               </motion.div>
             )}

--- a/Frontend/src/app/(protected)/dashboard/page.tsx
+++ b/Frontend/src/app/(protected)/dashboard/page.tsx
@@ -6,11 +6,16 @@ import { useVehicles } from "@/hooks/useVehicles";
 import Link from "next/link";
 import { Trash2 } from "lucide-react";
 import { motion } from "framer-motion";
+import { useAuth } from "@/contexts/AuthContext";
+import { formatCOP } from "@/lib/format";
 
 export default function DashboardPage() {
         const { vehicles, loading: vehLoading } = useVehicles();
         const [vehicleId, setVehicleId] = useState<string>("");
         const { trips, summary, loading, error, deleteTrip } = useTrips(vehicleId);
+        const { fuelPrices } = useAuth();
+        const corrientePrice = fuelPrices?.corriente ?? 0;
+        const extraPrice = fuelPrices?.extra ?? 0;
 
         React.useEffect(() => {
                 if (!vehicleId && vehicles.length > 0) {
@@ -120,10 +125,13 @@ export default function DashboardPage() {
 								<th className="px-6 py-3 text-left text-xs font-medium text-indigo-700 uppercase tracking-wider">
 									Km/Gal
 								</th>
-								<th className="px-6 py-3 text-left text-xs font-medium text-indigo-700 uppercase tracking-wider">
-									Km/Litro
-								</th>
-								<th className="px-6 py-3"></th>
+                                                               <th className="px-6 py-3 text-left text-xs font-medium text-indigo-700 uppercase tracking-wider">
+                                                                        Km/Litro
+                                                               </th>
+                                                               <th className="px-6 py-3 text-left text-xs font-medium text-indigo-700 uppercase tracking-wider">
+                                                                        Precio/Km
+                                                               </th>
+                                                               <th className="px-6 py-3"></th>
 							</tr>
 						</thead>
 						<tbody className="bg-white divide-y divide-gray-200">
@@ -144,21 +152,39 @@ export default function DashboardPage() {
 									<td className="px-6 py-4 whitespace-nowrap">
 										{(trip.kilometers / trip.gallons).toFixed(2)}
 									</td>
-									<td className="px-6 py-4 whitespace-nowrap">
-										{(trip.kilometers / trip.gallons / 3.78541).toFixed(2)}
-									</td>
-									<td className="px-6 py-4 whitespace-nowrap text-right">
-										<button
-											onClick={() => deleteTrip(trip._id)}
-											className="text-red-500 hover:text-red-700">
-											<Trash2 size={20} />
-										</button>
-									</td>
-								</motion.tr>
-							))}
-						</tbody>
-					</table>
-				</div>
+                                                                       <td className="px-6 py-4 whitespace-nowrap">
+                                                                               {(trip.kilometers / trip.gallons / 3.78541).toFixed(2)}
+                                                                       </td>
+                                                                       <td className="px-6 py-4 whitespace-nowrap">
+                                                                               {corrientePrice > 0 || extraPrice > 0 ? (
+                                                                                       <div className="flex flex-col">
+                                                                                               {corrientePrice > 0 && (
+                                                                                                       <span>
+                                                                                                               C: {formatCOP((trip.gallons * corrientePrice) / trip.kilometers)}
+                                                                                                       </span>
+                                                                                               )}
+                                                                                               {extraPrice > 0 && (
+                                                                                                       <span>
+                                                                                                               E: {formatCOP((trip.gallons * extraPrice) / trip.kilometers)}
+                                                                                                       </span>
+                                                                                               )}
+                                                                                       </div>
+                                                                               ) : (
+                                                                                       <span>N/A</span>
+                                                                               )}
+                                                                       </td>
+                                                                       <td className="px-6 py-4 whitespace-nowrap text-right">
+                                                                               <button
+                                                                                       onClick={() => deleteTrip(trip._id)}
+                                                                                       className="text-red-500 hover:text-red-700">
+                                                                                       <Trash2 size={20} />
+                                                                               </button>
+                                                                       </td>
+                                                               </motion.tr>
+                                                       ))}
+                                               </tbody>
+                                       </table>
+                               </div>
 			</motion.section>
 
 			{/* Footer CTA */}

--- a/Frontend/src/lib/format.ts
+++ b/Frontend/src/lib/format.ts
@@ -1,0 +1,4 @@
+export function formatCOP(value: number): string {
+  const rounded = Math.round(value);
+  return `$${rounded.toLocaleString("es-CO")}`;
+}


### PR DESCRIPTION
## Summary
- display cost per kilometer for corriente and extra fuels on dashboard
- show price per kilometer in calculator results
- add shared COP currency formatter

## Testing
- `npm run lint` *(fails: requires interactive eslint setup)*
- `npm run build`
- `npm test` *(fails: no test specified)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688fa8dad5ec832692c1cd854826cabf