### PR TITLE
feat: persist selected vehicle across pages

### DIFF
--- a/Frontend/src/app/(protected)/analytics/page.tsx
+++ b/Frontend/src/app/(protected)/analytics/page.tsx
@@ -1,20 +1,18 @@
 "use client";
 
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useMemo } from "react";
 import { useTrips } from "@/hooks/useTrips";
-import { useVehicles } from "@/hooks/useVehicles";
+import { useVehicle } from "@/contexts/VehicleContext";
 import { LineChart, ScatterChart } from "@/components/Charts";
 
 export default function AnalyticsPage() {
-	const { vehicles, loading: vehLoading } = useVehicles();
-	const [vehicleId, setVehicleId] = useState<string>("");
-	const { trips, summary, loading } = useTrips(vehicleId);
-
-	useEffect(() => {
-		if (!vehicleId && vehicles.length > 0) {
-			setVehicleId(vehicles[0]._id);
-		}
-	}, [vehicles, vehicleId]);
+        const {
+                vehicles,
+                loading: vehLoading,
+                selectedVehicleId,
+                setSelectedVehicleId,
+        } = useVehicle();
+        const { trips, summary, loading } = useTrips(selectedVehicleId);
 
 	// Todos los hooks deben estar antes de cualquier return condicional
 	const slopeGalPerKm = useMemo(() => {
@@ -42,14 +40,14 @@ export default function AnalyticsPage() {
 	}, [trips, slopeGalPerKm]);
 
 	// Returns condicionales después de todos los hooks
-	if (vehLoading || loading)
-		return <p className="p-4 text-center text-gray-500">Cargando datos...</p>;
-	if (!vehicleId && vehicles.length === 0)
-		return (
-			<p className="p-4 text-center text-gray-500">
-				Debes crear un vehículo antes de continuar.
-			</p>
-		);
+        if (vehLoading || loading)
+                return <p className="p-4 text-center text-gray-500">Cargando datos...</p>;
+        if (!selectedVehicleId && vehicles.length === 0)
+                return (
+                        <p className="p-4 text-center text-gray-500">
+                                Debes crear un vehículo antes de continuar.
+                        </p>
+                );
 
 	const scatterPoints = trips.map((t) => ({ x: t.kilometers, y: t.gallons }));
 	const kmPerGallon = trips.map((t) => t.kilometers / t.gallons);
@@ -59,10 +57,10 @@ export default function AnalyticsPage() {
 		<div className="p-4 space-y-8">
 			<h1 className="text-2xl font-bold text-indigo-600">Estadísticas</h1>
 			<div>
-				<select
-					value={vehicleId}
-					onChange={(e) => setVehicleId(e.target.value)}
-					className="border rounded p-2">
+                                <select
+                                        value={selectedVehicleId}
+                                        onChange={(e) => setSelectedVehicleId(e.target.value)}
+                                        className="border rounded p-2">
 					{vehicles.map((v) => (
 						<option
 							key={v._id}

--- a/Frontend/src/app/(protected)/calculator/page.tsx
+++ b/Frontend/src/app/(protected)/calculator/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from "react";
 import { useCalculate } from "@/hooks/useCalculate";
-import { useVehicles } from "@/hooks/useVehicles";
+import { useVehicle } from "@/contexts/VehicleContext";
 import Link from "next/link";
 import { motion } from "framer-motion";
 import { Input } from "@/components/ui/input";
@@ -13,21 +13,19 @@ import { useAuth } from "@/contexts/AuthContext";
 import { formatCOP } from "@/lib/format";
 
 export default function CalculatorPage() {
-  const { vehicles, loading: vehLoading } = useVehicles();
-  const [vehicleId, setVehicleId] = useState<string>("");
+  const {
+    vehicles,
+    loading: vehLoading,
+    selectedVehicleId,
+    setSelectedVehicleId,
+  } = useVehicle();
   const [km, setKm] = useState<string>("");
-  const { data, loading, error, calculate } = useCalculate(vehicleId);
+  const { data, loading, error, calculate } = useCalculate(selectedVehicleId);
   const { fuelPrices } = useAuth();
 
   const corrientePrice = fuelPrices?.corriente ?? 0;
   const extraPrice = fuelPrices?.extra ?? 0;
   const noPrices = corrientePrice <= 0 && extraPrice <= 0;
-
-  React.useEffect(() => {
-    if (!vehicleId && vehicles.length > 0) {
-      setVehicleId(vehicles[0]._id);
-    }
-  }, [vehicles, vehicleId]);
 
   const handleKmChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
@@ -69,7 +67,7 @@ export default function CalculatorPage() {
 
   if (vehLoading)
     return <p className="p-4 text-center text-gray-500">Cargando datos...</p>;
-  if (!vehicleId && vehicles.length === 0)
+  if (!selectedVehicleId && vehicles.length === 0)
     return (
       <p className="p-4 text-center text-gray-500">Debes crear un vehículo antes de continuar.</p>
     );
@@ -109,8 +107,8 @@ export default function CalculatorPage() {
               <div>
                 <Label className="text-gray-600">Vehículo</Label>
                 <select
-                  value={vehicleId}
-                  onChange={(e) => setVehicleId(e.target.value)}
+                  value={selectedVehicleId}
+                  onChange={(e) => setSelectedVehicleId(e.target.value)}
                   className="mt-1 w-full border rounded p-2"
                 >
                   {vehicles.map((v) => (

--- a/Frontend/src/app/(protected)/dashboard/page.tsx
+++ b/Frontend/src/app/(protected)/dashboard/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import React, { useState } from "react";
 import { useTrips } from "@/hooks/useTrips";
-import { useVehicles } from "@/hooks/useVehicles";
+import { useVehicle } from "@/contexts/VehicleContext";
 import Link from "next/link";
 import { Trash2 } from "lucide-react";
 import { motion } from "framer-motion";
@@ -10,23 +9,21 @@ import { useAuth } from "@/contexts/AuthContext";
 import { formatCOP } from "@/lib/format";
 
 export default function DashboardPage() {
-        const { vehicles, loading: vehLoading } = useVehicles();
-        const [vehicleId, setVehicleId] = useState<string>("");
-        const { trips, summary, loading, error, deleteTrip } = useTrips(vehicleId);
+        const {
+                vehicles,
+                loading: vehLoading,
+                selectedVehicleId,
+                setSelectedVehicleId,
+        } = useVehicle();
+        const { trips, summary, loading, error, deleteTrip } = useTrips(selectedVehicleId);
         const { fuelPrices } = useAuth();
         const corrientePrice = fuelPrices?.corriente ?? 0;
         const extraPrice = fuelPrices?.extra ?? 0;
 
-        React.useEffect(() => {
-                if (!vehicleId && vehicles.length > 0) {
-                        setVehicleId(vehicles[0]._id);
-                }
-        }, [vehicles, vehicleId]);
-
         if (vehLoading || loading)
                 return <p className="p-4 text-center text-gray-500">Cargando datos...</p>;
         if (error) return <p className="p-4 text-center text-red-500">{error}</p>;
-        if (!vehicleId && vehicles.length === 0)
+        if (!selectedVehicleId && vehicles.length === 0)
                 return (
                         <p className="p-4 text-center text-gray-500">
                                 Debes crear un vehículo antes de continuar.
@@ -50,8 +47,8 @@ export default function DashboardPage() {
 				</p>
                                 <div className="flex flex-col items-center gap-4">
                                         <select
-                                                value={vehicleId}
-                                                onChange={(e) => setVehicleId(e.target.value)}
+                                                value={selectedVehicleId}
+                                                onChange={(e) => setSelectedVehicleId(e.target.value)}
                                                 className="border rounded p-2">
                                                 {vehicles.map((v) => (
                                                         <option key={v._id} value={v._id}>

--- a/Frontend/src/app/(protected)/trips/new/page.tsx
+++ b/Frontend/src/app/(protected)/trips/new/page.tsx
@@ -10,7 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Card, CardHeader, CardContent, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import { useVehicles } from "@/hooks/useVehicles";
+import { useVehicle } from "@/contexts/VehicleContext";
 
 export default function NewTripPage() {
 	const router = useRouter();
@@ -18,8 +18,12 @@ export default function NewTripPage() {
 	/** ----------------------------------
 	 *  Shared state & helpers
 	 * ---------------------------------*/
-        const { vehicles, loading: vehLoading } = useVehicles();
-        const [vehicleId, setVehicleId] = useState<string>("");
+        const {
+                vehicles,
+                loading: vehLoading,
+                selectedVehicleId,
+                setSelectedVehicleId,
+        } = useVehicle();
         const [selectedTab, setSelectedTab] = useState<string>("direct");
 	const [gallons, setGallons] = useState<string>("");
 	const [loading, setLoading] = useState(false);
@@ -32,15 +36,9 @@ export default function NewTripPage() {
 	const [initialKm, setInitialKm] = useState<string>("");
         const [finalKm, setFinalKm] = useState<string>("");
 
-        React.useEffect(() => {
-                if (!vehicleId && vehicles.length > 0) {
-                        setVehicleId(vehicles[0]._id);
-                }
-        }, [vehicles, vehicleId]);
-
         if (vehLoading)
                 return <p className="p-4 text-center text-gray-500">Cargando datos...</p>;
-        if (!vehicleId && vehicles.length === 0)
+        if (!selectedVehicleId && vehicles.length === 0)
                 return <p className="p-4 text-center text-gray-500">Debes crear un vehículo antes de continuar.</p>;
 
 	const isValidNumber = (value: string) => /^[0-9]*[.,]?[0-9]*$/.test(value);
@@ -78,7 +76,7 @@ export default function NewTripPage() {
                 e.preventDefault();
                 setError(null);
 
-                if (!vehicleId) {
+                if (!selectedVehicleId) {
                         setError("Debes crear un vehículo antes");
                         return;
                 }
@@ -122,7 +120,7 @@ export default function NewTripPage() {
 
                 setLoading(true);
                 try {
-                        await api.post("/trips", { vehicleId, kilometers: kmNumber, gallons: galNumber });
+                        await api.post("/trips", { vehicleId: selectedVehicleId, kilometers: kmNumber, gallons: galNumber });
                         router.push("/dashboard");
 		} catch (err: any) {
 			setError(err.response?.data?.message || "Error al guardar el viaje");
@@ -166,8 +164,8 @@ export default function NewTripPage() {
                                                 <div className="mb-4">
                                                         <Label className="text-gray-600">Vehículo</Label>
                                                         <select
-                                                                value={vehicleId}
-                                                                onChange={(e) => setVehicleId(e.target.value)}
+                                                                value={selectedVehicleId}
+                                                                onChange={(e) => setSelectedVehicleId(e.target.value)}
                                                                 className="mt-1 w-full border rounded p-2">
                                                                 {vehicles.map((v) => (
                                                                         <option key={v._id} value={v._id}>

--- a/Frontend/src/app/(protected)/vehicles/page.tsx
+++ b/Frontend/src/app/(protected)/vehicles/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import { useVehicles } from "@/hooks/useVehicles";
+import { useVehicle } from "@/contexts/VehicleContext";
 import { Card, CardHeader, CardContent, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -12,7 +12,7 @@ import { Trash2 } from "lucide-react";
 import { motion } from "framer-motion";
 
 export default function VehiclesPage() {
-    const { vehicles, loading, error, createVehicle, updateVehicle, deleteVehicle } = useVehicles();
+    const { vehicles, loading, error, createVehicle, updateVehicle, deleteVehicle } = useVehicle();
     const [name, setName] = useState("");
     const [licensePlate, setLicensePlate] = useState("");
     const [editId, setEditId] = useState<string | null>(null);

--- a/Frontend/src/app/layout.tsx
+++ b/Frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { AuthProvider } from "../contexts/AuthContext";
+import { VehicleProvider } from "../contexts/VehicleContext";
 import "./globals.css";
 import NavBar from "@/components/NavBar";
 
@@ -17,10 +18,12 @@ export default function RootLayout({
 	return (
 		<html lang="es">
 			<body>
-				<AuthProvider>
-					<NavBar />
-					<main>{children}</main>
-				</AuthProvider>
+                                <AuthProvider>
+                                        <VehicleProvider>
+                                                <NavBar />
+                                                <main>{children}</main>
+                                        </VehicleProvider>
+                                </AuthProvider>
 			</body>
 		</html>
 	);

--- a/Frontend/src/contexts/VehicleContext.tsx
+++ b/Frontend/src/contexts/VehicleContext.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState, ReactNode } from "react";
+import { Vehicle } from "@/types";
+import { useVehicles } from "@/hooks/useVehicles";
+import { useAuth } from "./AuthContext";
+
+interface VehicleContextType {
+        vehicles: Vehicle[];
+        loading: boolean;
+        error: string | null;
+        selectedVehicleId: string;
+        setSelectedVehicleId: (id: string) => void;
+        createVehicle: (name: string, licensePlate: string) => Promise<void>;
+        updateVehicle: (
+                id: string,
+                data: { name: string; licensePlate: string }
+        ) => Promise<void>;
+        deleteVehicle: (id: string) => Promise<void>;
+}
+
+const VehicleContext = createContext<VehicleContextType | undefined>(undefined);
+
+export function VehicleProvider({ children }: { children: ReactNode }) {
+        const { user } = useAuth();
+        const {
+                vehicles,
+                loading,
+                error,
+                createVehicle,
+                updateVehicle,
+                deleteVehicle,
+        } = useVehicles(!!user);
+        const [selectedVehicleId, setSelectedVehicleId] = useState<string>("");
+
+        useEffect(() => {
+                const stored = typeof window !== "undefined" ? localStorage.getItem("selectedVehicleId") : null;
+                if (stored) {
+                        setSelectedVehicleId(stored);
+                }
+        }, []);
+
+        useEffect(() => {
+                if (!selectedVehicleId && vehicles.length > 0) {
+                        setSelectedVehicleId(vehicles[0]._id);
+                }
+        }, [vehicles, selectedVehicleId]);
+
+        useEffect(() => {
+                if (selectedVehicleId) {
+                        localStorage.setItem("selectedVehicleId", selectedVehicleId);
+                }
+        }, [selectedVehicleId]);
+
+        return (
+                <VehicleContext.Provider
+                        value={{
+                                vehicles,
+                                loading,
+                                error,
+                                selectedVehicleId,
+                                setSelectedVehicleId,
+                                createVehicle,
+                                updateVehicle,
+                                deleteVehicle,
+                        }}>
+                        {children}
+                </VehicleContext.Provider>
+        );
+}
+
+export function useVehicle() {
+        const ctx = useContext(VehicleContext);
+        if (!ctx) throw new Error("useVehicle must be inside VehicleProvider");
+        return ctx;
+}
+

--- a/Frontend/src/hooks/useVehicles.ts
+++ b/Frontend/src/hooks/useVehicles.ts
@@ -4,7 +4,7 @@ import { useState, useCallback, useEffect } from "react";
 import api from "@/lib/api";
 import { Vehicle } from "@/types";
 
-export function useVehicles() {
+export function useVehicles(enabled = true) {
     const [vehicles, setVehicles] = useState<Vehicle[]>([]);
     const [loading, setLoading] = useState<boolean>(true);
     const [error, setError] = useState<string | null>(null);
@@ -19,8 +19,13 @@ export function useVehicles() {
     }, []);
 
     useEffect(() => {
+        if (!enabled) {
+            setVehicles([]);
+            setLoading(false);
+            return;
+        }
         fetchVehicles();
-    }, [fetchVehicles]);
+    }, [fetchVehicles, enabled]);
 
     const createVehicle = async (name: string, licensePlate: string) => {
         await api.post("/vehicles", { name, licensePlate });


### PR DESCRIPTION
## Summary
- add VehicleContext to store selected vehicle globally and persist to localStorage
- wrap app with VehicleProvider and update pages to use shared selection
- allow useVehicles hook to skip fetch when user is unauthenticated

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b4fda0dc8883268a03a44837907da6