### PR TITLE
feat: parallelize trip summary fetch

### DIFF
--- a/Frontend/src/hooks/useTrips.ts
+++ b/Frontend/src/hooks/useTrips.ts
@@ -2,11 +2,12 @@
 
 import useSWR from "swr";
 import api from "@/lib/api";
-import { ITrip, TripSummaryResponse } from "@/types";
+import { ITrip, TripSummaryResponse, FuelPrices } from "@/types";
 
 interface TripsData {
         trips: ITrip[];
         summary: TripSummaryResponse;
+        prices: FuelPrices;
 }
 
 export function useTrips(vehicleId: string) {
@@ -23,6 +24,7 @@ export function useTrips(vehicleId: string) {
         return {
                 trips: data?.trips ?? [],
                 summary: data?.summary ?? null,
+                prices: data?.prices ?? null,
                 loading: isLoading,
                 error: error instanceof Error ? error.message : null,
                 deleteTrip,


### PR DESCRIPTION
## Summary
- fetch trip list and fuel prices in parallel to build summary
- reuse fetched prices for cost calculation
- expose fuel prices through trips hook

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*
- `npm install`
- `npm run build`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b50ab36d2c8326818ceb5b85eadddc