### PR TITLE
feat: cache fuel prices

### DIFF
--- a/Backend/src/config/index.ts
+++ b/Backend/src/config/index.ts
@@ -2,10 +2,11 @@ import dotenv from "dotenv";
 dotenv.config();
 
 export const config = {
-	PORT: process.env.PORT ?? 4000,
-	MONGO_URI: process.env.MONGO_URI,
-	JWT_SECRET: process.env.JWT_SECRET!,
-	GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
-	GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
-	OAUTH_CALLBACK_URL: process.env.OAUTH_CALLBACK_URL,
+        PORT: process.env.PORT ?? 4000,
+        MONGO_URI: process.env.MONGO_URI,
+        JWT_SECRET: process.env.JWT_SECRET!,
+        GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
+        GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
+        OAUTH_CALLBACK_URL: process.env.OAUTH_CALLBACK_URL,
+        FUEL_PRICE_TTL_MS: Number(process.env.FUEL_PRICE_TTL_MS) || 5 * 60 * 1000,
 };

--- a/Backend/src/controllers/FuelPriceController.ts
+++ b/Backend/src/controllers/FuelPriceController.ts
@@ -1,7 +1,8 @@
 import { Request, Response } from "express";
 import { FuelPriceService } from "../services/FuelPriceService";
+import { config } from "../config";
 
-const service = new FuelPriceService();
+const service = new FuelPriceService(config.FUEL_PRICE_TTL_MS);
 
 export class FuelPriceController {
         static async getPrices(_req: Request, res: Response) {

--- a/Backend/src/services/FuelPriceService.ts
+++ b/Backend/src/services/FuelPriceService.ts
@@ -3,12 +3,26 @@ import { IFuelPrice } from "../models/FuelPrice";
 
 export class FuelPriceService {
         private repo = new FuelPriceRepository();
+        private cachedPrice: IFuelPrice | null = null;
+        private cacheTime = 0;
 
-        getPrices(): Promise<IFuelPrice> {
-                return this.repo.get();
+        constructor(private ttl: number = 5 * 60 * 1000) {}
+
+        async getPrices(): Promise<IFuelPrice> {
+                const now = Date.now();
+                if (this.cachedPrice && now - this.cacheTime < this.ttl) {
+                        return this.cachedPrice;
+                }
+                const price = await this.repo.get();
+                this.cachedPrice = price;
+                this.cacheTime = now;
+                return price;
         }
 
-        updatePrices(prices: { corriente?: number; extra?: number }): Promise<IFuelPrice> {
-                return this.repo.update(prices);
+        async updatePrices(prices: { corriente?: number; extra?: number }): Promise<IFuelPrice> {
+                const updated = await this.repo.update(prices);
+                this.cachedPrice = null;
+                this.cacheTime = 0;
+                return updated;
         }
 }

--- a/Backend/src/services/TripService.ts
+++ b/Backend/src/services/TripService.ts
@@ -2,6 +2,7 @@ import { TripRepository } from "../repositories/TripRepository";
 import { VehicleService } from "./VehicleService";
 import { FuelPriceService } from "./FuelPriceService";
 import { ITrip } from "../models/Trip";
+import { config } from "../config";
 import {
 	average,
 	gallonsToLiters,
@@ -13,7 +14,7 @@ import {
 export class TripService {
         private tripRepo = new TripRepository();
         private vehicleSvc = new VehicleService();
-        private fuelPriceSvc = new FuelPriceService();
+        private fuelPriceSvc = new FuelPriceService(config.FUEL_PRICE_TTL_MS);
 
         async create(userId: string, vehicleId: string, km: number, gal: number): Promise<ITrip> {
                 await this.vehicleSvc.ensureDefaultVehicle(userId);


### PR DESCRIPTION
## Summary
- add TTL-based caching to FuelPriceService with cache invalidation
- expose FUEL_PRICE_TTL_MS config and use it across services

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b50d28343883268c962987026ff7d7