### PR TITLE
feat: generate sitemap and robots

### DIFF
--- a/Frontend/.gitignore
+++ b/Frontend/.gitignore
@@ -20,6 +20,10 @@
 # production
 /build
 
+# PWA generated assets
+/public/sw.js
+/public/workbox-*.js
+
 # misc
 .DS_Store
 *.pem

--- a/Frontend/next-sitemap.config.js
+++ b/Frontend/next-sitemap.config.js
@@ -1,0 +1,9 @@
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://tripfuel.example.com';
+
+module.exports = {
+  siteUrl,
+  generateRobotsTxt: true,
+  robotsTxtOptions: {
+    policies: [{ userAgent: '*', allow: '/' }],
+  },
+};

--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -31,6 +31,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "next-sitemap": "^4.2.3",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -1539,6 +1540,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@corex/deepmerge": {
+      "version": "4.0.43",
+      "resolved": "https://registry.npmjs.org/@corex/deepmerge/-/deepmerge-4.0.43.tgz",
+      "integrity": "sha512-N8uEMrMPL0cu/bdboEWpQYb/0i2K5Qn8eCsxzOmxSggJbbQte7ljMRoXm917AbntqTGOzdTu+vP3KOOzoC70HQ==",
+      "dev": true
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.4.3",
@@ -5751,6 +5758,15 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/motion": {
       "version": "12.7.4",
       "resolved": "https://registry.npmjs.org/motion/-/motion-12.7.4.tgz",
@@ -5893,6 +5909,39 @@
       "peerDependencies": {
         "next": ">=9.0.0"
       }
+    },
+    "node_modules/next-sitemap": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/next-sitemap/-/next-sitemap-4.2.3.tgz",
+      "integrity": "sha512-vjdCxeDuWDzldhCnyFCQipw5bfpl4HmZA7uoo3GAaYGjGgfL4Cxb1CiztPuWGmS+auYs7/8OekRS8C2cjdAsjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "url": "https://github.com/iamvishnusankar/next-sitemap.git"
+        }
+      ],
+      "dependencies": {
+        "@corex/deepmerge": "^4.0.43",
+        "@next/env": "^13.4.3",
+        "fast-glob": "^3.2.12",
+        "minimist": "^1.2.8"
+      },
+      "bin": {
+        "next-sitemap": "bin/next-sitemap.mjs",
+        "next-sitemap-cjs": "bin/next-sitemap.cjs"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "peerDependencies": {
+        "next": "*"
+      }
+    },
+    "node_modules/next-sitemap/node_modules/@next/env": {
+      "version": "13.5.11",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.11.tgz",
+      "integrity": "sha512-fbb2C7HChgM7CemdCY+y3N1n8pcTKdqtQLbC7/EQtPdLvlMUT9JX/dBYl8MMZAtYG4uVMyPFHXckb68q/NRwqg==",
+      "dev": true
     },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",
+    "postbuild": "next-sitemap",
     "start": "next start",
     "lint": "next lint"
   },
@@ -19,19 +20,20 @@
     "lucide-react": "^0.501.0",
     "motion": "^12.7.4",
     "next": "15.3.1",
+    "next-pwa": "^5.6.0",
     "react": "^19.0.0",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.0.0",
     "swr": "^2.3.6",
     "tailwind-merge": "^3.2.0",
-    "tw-animate-css": "^1.2.5",
-    "next-pwa": "^5.6.0"
+    "tw-animate-css": "^1.2.5"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "next-sitemap": "^4.2.3",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/Frontend/public/robots.txt
+++ b/Frontend/public/robots.txt
@@ -1,0 +1,9 @@
+# *
+User-agent: *
+Allow: /
+
+# Host
+Host: https://tripfuel.example.com
+
+# Sitemaps
+Sitemap: https://tripfuel.example.com/sitemap.xml

--- a/Frontend/public/sitemap-0.xml
+++ b/Frontend/public/sitemap-0.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+<url><loc>https://tripfuel.example.com/login</loc><lastmod>2025-09-07T22:46:57.939Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://tripfuel.example.com/privacity</loc><lastmod>2025-09-07T22:46:57.939Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://tripfuel.example.com/signup</loc><lastmod>2025-09-07T22:46:57.939Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://tripfuel.example.com/terms-of-service</loc><lastmod>2025-09-07T22:46:57.939Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://tripfuel.example.com</loc><lastmod>2025-09-07T22:46:57.939Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://tripfuel.example.com/calculator</loc><lastmod>2025-09-07T22:46:57.939Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://tripfuel.example.com/dashboard</loc><lastmod>2025-09-07T22:46:57.939Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://tripfuel.example.com/analytics</loc><lastmod>2025-09-07T22:46:57.939Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://tripfuel.example.com/settings</loc><lastmod>2025-09-07T22:46:57.939Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://tripfuel.example.com/trips/new</loc><lastmod>2025-09-07T22:46:57.939Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://tripfuel.example.com/vehicles</loc><lastmod>2025-09-07T22:46:57.939Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://tripfuel.example.com/auth/social</loc><lastmod>2025-09-07T22:46:57.940Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+</urlset>

--- a/Frontend/public/sitemap.xml
+++ b/Frontend/public/sitemap.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>https://tripfuel.example.com/sitemap-0.xml</loc></sitemap>
+</sitemapindex>


### PR DESCRIPTION
## Summary
- generate sitemap and robots at build time using next-sitemap
- expose sitemap.xml and robots.txt to aid indexing
- ignore PWA build artifacts

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68be09c01a208326b2d535383a334962